### PR TITLE
Feat: Replace navbar text brand with dual image logos

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -13,7 +13,10 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg bg-secondary text-uppercase fixed-top" id="mainNav">
         <div class="container">
-            <a class="navbar-brand" href="#page-top">lsp-dks</a>
+            <a class="navbar-brand navbar-brand-logos" href="#page-top">
+                <img src="assets/img/logo-bnsp.png" alt="BNSP Logo">
+                <img src="assets/img/logo-digitalcreativesolusi.png" alt="Digital Creative Solusi Logo">
+            </a>
             <button class="navbar-toggler text-uppercase font-weight-bold bg-primary text-white rounded" type="button"
                 data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
                 aria-expanded="false" aria-label="Toggle navigation">

--- a/css/styles.css
+++ b/css/styles.css
@@ -10900,6 +10900,15 @@ html {
 #mainNav .navbar-brand {
   color: #fff;
 }
+/* Styles for the new dual logos in navbar */
+#mainNav .navbar-brand-logos img {
+  height: 35px; /* Default height */
+  vertical-align: middle; /* Aligns images nicely with any potential text or each other */
+}
+#mainNav .navbar-brand-logos img:first-of-type {
+  margin-right: 10px; /* Space between the two logos */
+}
+
 #mainNav .navbar-nav {
   margin-top: 1rem;
 }

--- a/index.php
+++ b/index.php
@@ -21,7 +21,10 @@
     <!-- Navigation-->
     <nav class="navbar navbar-expand-lg bg-secondary text-uppercase fixed-top" id="mainNav">
         <div class="container">
-            <a class="navbar-brand" href="#page-top">lsp-dks</a>
+            <a class="navbar-brand navbar-brand-logos" href="#page-top">
+                <img src="assets/img/logo-bnsp.png" alt="BNSP Logo">
+                <img src="assets/img/logo-digitalcreativesolusi.png" alt="Digital Creative Solusi Logo">
+            </a>
 
             <button class="navbar-toggler text-uppercase font-weight-bold bg-primary text-white rounded" type="button"
                 data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"

--- a/profile.php
+++ b/profile.php
@@ -13,7 +13,10 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg bg-secondary text-uppercase fixed-top" id="mainNav">
         <div class="container">
-            <a class="navbar-brand" href="#page-top">lsp-dks</a>
+            <a class="navbar-brand navbar-brand-logos" href="#page-top">
+                <img src="assets/img/logo-bnsp.png" alt="BNSP Logo">
+                <img src="assets/img/logo-digitalcreativesolusi.png" alt="Digital Creative Solusi Logo">
+            </a>
             <button class="navbar-toggler text-uppercase font-weight-bold bg-primary text-white rounded" type="button"
                 data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
                 aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Updated index.php, blog.php, and profile.php to display logo-bnsp.png and logo-digitalcreativesolusi.png in the navbar instead of the text 'lsp-dks'.

Added CSS class .navbar-brand-logos to style the images for consistent height, alignment, and spacing.