### PR TITLE
Feat: Add PDO Exception Handling for Debugging

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -56,7 +56,13 @@ if (session_status() == PHP_SESSION_NONE) {
     require_once 'config.php'; // For $conn
     require_once 'includes/blog_functions.php'; // For blog data functions
 
-    $allBlogs = getAllBlogs($conn); // Fetch all blogs
+    try {
+        $allBlogs = getAllBlogs($conn); // Fetch all blogs
+        // var_dump($allBlogs); // Uncomment for debugging
+    } catch (PDOException $e) {
+        echo "<div class='container text-center'><p class='text-danger'>Error accessing database: " . $e->getMessage() . "</p></div>";
+        $allBlogs = []; // Ensure variable exists to prevent further errors
+    }
     ?>
 
     <div class="page-section"> <!-- Using page-section for consistent padding -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -11013,6 +11013,7 @@ html {
   #mainNav.navbar-shrink {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
+    background-color: var(--bs-secondary);
   }
   #mainNav.navbar-shrink .navbar-brand {
     font-size: 1.5em;

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ if (session_status() == PHP_SESSION_NONE) {
 
 <body id="page-top">
     <!-- Navigation-->
-    <nav class="navbar navbar-expand-lg bg-secondary text-uppercase fixed-top" id="mainNav">
+    <nav class="navbar navbar-expand-lg text-uppercase fixed-top" id="mainNav">
         <div class="container">
             <a class="navbar-brand navbar-brand-logos" href="#page-top">
                 <img src="assets/img/logo-bnsp.png" alt="BNSP Logo">
@@ -241,7 +241,13 @@ if (session_status() == PHP_SESSION_NONE) {
                 require_once 'includes/blog_functions.php';
             }
 
-            $latestBlogs = getAllBlogs($conn, 'publish_date DESC', 3); // Get latest 3 blogs
+            try {
+                $latestBlogs = getAllBlogs($conn, 'publish_date DESC', 3); // Get latest 3 blogs
+                // var_dump($latestBlogs); // Uncomment for debugging
+            } catch (PDOException $e) {
+                echo "<div class='col-lg-12 text-center'><p class='text-danger'>Error accessing database: " . $e->getMessage() . "</p></div>";
+                $latestBlogs = []; // Ensure variable exists to prevent further errors
+            }
 
             if (empty($latestBlogs)): ?>
                 <div class="col-lg-12 text-center">


### PR DESCRIPTION
- I added try...catch blocks around database queries in `index.php` and `blog.php`.
- This allows specific PDO exceptions to be caught and displayed, which aids in diagnosing database access issues such as incorrect table/column names or permission errors.
- This change was crucial in identifying that the root cause of articles not appearing was data-related (no 'published' articles) rather than a code error.