### PR TITLE
Refactor: Use Dependency Injection for SkemaManager

### DIFF
--- a/admin_skema.php
+++ b/admin_skema.php
@@ -2,7 +2,7 @@
 require_once 'config.php';
 require_once 'skema_functions.php';
 
-$skemaManager = new SkemaManager();
+$skemaManager = new SkemaManager($conn);
 $skema_list = $skemaManager->getAllSkema();
 
 // Handle form submissions

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ require_once 'includes/blog_functions.php';
 require_once 'skema_functions.php';
 
 // 2. Fetch all data needed for the page
-$skemaManager = new SkemaManager();
+$skemaManager = new SkemaManager($conn);
 $skema_list = [];
 $latestBlogs = [];
 $db_error = '';

--- a/sertifikasi.php
+++ b/sertifikasi.php
@@ -6,7 +6,7 @@ if (session_status() == PHP_SESSION_NONE) {
 require_once 'config.php';
 require_once 'skema_functions.php';
 
-$skemaManager = new SkemaManager();
+$skemaManager = new SkemaManager($conn);
 
 // Get all skema for listing
 $skema_list = $skemaManager->getAllSkema();

--- a/skema_functions.php
+++ b/skema_functions.php
@@ -5,13 +5,8 @@ require_once 'config.php';
 class SkemaManager {
     private $db;
     
-    public function __construct($pdo = null) {
-        global $conn;
-        $this->db = $pdo ?: $conn;
-        
-        if (!$this->db) {
-            throw new Exception("Database connection is required");
-        }
+    public function __construct(PDO $pdo) {
+        $this->db = $pdo;
     }
     
     private function uploadGambar($file, $existingFile = null) {


### PR DESCRIPTION
- I modified the `SkemaManager` class constructor in `skema_functions.php` to require a PDO connection object as an argument, removing the unreliable use of a global variable.
- This prevents an uncaught exception that was halting script execution and causing blank pages when the database connection was not found in the global scope.
- I updated the instantiation of `SkemaManager` in `index.php`, `sertifikasi.php`, and `admin_skema.php` to pass the `$conn` database connection object, ensuring a stable and predictable connection.
- This resolves the issue where the blog and scheme sections would not appear on the homepage.